### PR TITLE
Add win_psrepository

### DIFF
--- a/lib/ansible/modules/windows/win_psrepository.ps1
+++ b/lib/ansible/modules/windows/win_psrepository.ps1
@@ -10,8 +10,8 @@
 
 $params = Parse-Args -arguments $args -supports_check_mode $true
 
-$name = Get-AnsibleParam -obj $params -name "name" -type "str" -aliasses "repository" -failifempty $true
-$url = Get-AnsibleParam -obj $params -name "source_location" -type "str" -aliasses "url"
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -aliases "repository" -failifempty $true
+$url = Get-AnsibleParam -obj $params -name "source_location" -type "str" -aliases "url"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent"
 $installationpolicy = Get-AnsibleParam -obj $params -name "installation_policy" -type "str" -validateset "trusted", "untrusted"
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
@@ -90,6 +90,9 @@ if ($PsVersion.Major -lt 5){
     $ErrorMessage = "Windows PowerShell 5.0 or higher is needed."
     Fail-Json $result $ErrorMessage
 }
+
+# Check NuGet version, fail if < 2.8.5.201
+$NugetVersion = (Get-PackageProvider -Name Nuget).Version
 
 $Repos = Get-PSRepository
 

--- a/lib/ansible/modules/windows/win_psrepository.ps1
+++ b/lib/ansible/modules/windows/win_psrepository.ps1
@@ -1,0 +1,128 @@
+#!powershell
+
+# Copyright: (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+# Copyright: (c) 2018, Wojciech Sciesinski <wojciech[at]sciesinski[dot]net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+# win_psrepository (Windows PowerShell repositories Additions/Removals/Updates)
+
+$params = Parse-Args -arguments $args -supports_check_mode $true
+
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -aliasses "repository" -failifempty $true
+$url = Get-AnsibleParam -obj $params -name "source_location" -type "str" -aliasses "url"
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent"
+$installationpolicy = Get-AnsibleParam -obj $params -name "installation_policy" -type "str" -validateset "trusted", "untrusted"
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
+
+$result = @{"changed" = $false
+            "output" = ""}
+
+Function Install-Repository {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [String]$Name,
+        [Parameter(Mandatory=$true)]
+        [String]$Url,
+        [String]$InstallationPolicy,
+        [Bool]$CheckMode
+    )
+        try {
+            if (-not($CheckMode)) {
+               Register-PSRepository -Name $Name -SourceLocation $Url -InstallationPolicy $InstallationPolicy
+            }
+            $result.output = "The repository $Name with the SourceLocation $Url was registered."
+            $result.changed = $true
+        }
+        catch {
+            $ErrorMessage = "Problems adding $($Name) repository: $($_.Exception.Message)"
+            Fail-Json $result $ErrorMessage
+        }
+}
+
+Function Remove-Repository {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [String]$Name,
+        [Bool]$CheckMode
+    )
+    $ReposNames = (Get-PSRepository).Name
+
+    if ($ReposNames -contains $Name){
+        try {
+            if (-not ($CheckMode)) {
+                Unregister-PSRepository -Name $Name
+            }
+            $result.output = "The repository $Name was unregistered."
+            $result.changed = $true
+        }
+        catch {
+            $ErrorMessage = "Problems removing $($Name) repository: $($_.Exception.Message)"
+            Fail-Json $result $ErrorMessage
+        }
+    }
+}
+
+Function Set-Repository {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [String]$Name,
+        [String]$InstallationPolicy,
+        [Bool]$CheckMode
+    )
+    try {
+        if (-not ($CheckMode)) {
+            Set-PSRepository -Name $Name -InstallationPolicy $InstallationPolicy
+        }
+        $result.output = "The InstallationPolicy for the repository $Name was changed to $InstallationPolicy."
+        $result.changed = $true
+    }
+    catch {
+        $ErrorMessage = "Problems changing the InstallationPolicy for $($Name) repository: $($_.Exception.Message)"
+        Fail-Json $result $ErrorMessage
+    }
+}
+
+# Check PowerShell version, fail if < 5.0
+$PsVersion = $PSVersionTable.PSVersion
+if ($PsVersion.Major -lt 5){
+    $ErrorMessage = "Windows PowerShell 5.0 or higher is needed."
+    Fail-Json $result $ErrorMessage
+}
+
+$Repos = Get-PSRepository
+
+if ($state -eq "present") {
+    if ($name -and $url) {
+        $ReposSourceLocations = ($Repos).SourceLocation
+        # If repository isn't already present, try to register it.
+        if ($ReposSourceLocations -notcontains $Url){
+            if ( $installationpolicy ) {
+                $installationpolicy_internal = $installationpolicy
+            }
+            else {
+                $installationpolicy_internal = "Trusted"
+            }
+
+            Install-Repository -Name $name -Url $url -InstallationPolicy $installationpolicy_internal -CheckMode $check_mode
+        }
+    }
+    elseif ($name -and $installationpolicy) {
+        $ExistingInstallationPolicy = $($Repos | Where-Object { $_.Name -eq $Name }).InstallationPolicy
+        if ( $ExistingInstallationPolicy -ne $installationpolicy ) {
+            Set-Repository -Name $Name -InstallationPolicy $installationpolicy -CheckMode $check_mode
+        }
+    }
+    else {
+        $ErrorMessage = "Repository Name and Url are mandatory if you want to add a new repository."
+        Fail-Json $result $ErrorMessage
+    }
+}
+elseif ($state -eq "absent") {
+    if ( $name ) {
+        Remove-Repository -Name $name -CheckMode $check_mode
+    }
+}
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_psrepository.ps1
+++ b/lib/ansible/modules/windows/win_psrepository.ps1
@@ -93,6 +93,10 @@ if ($PsVersion.Major -lt 5){
 
 # Check NuGet version, fail if < 2.8.5.201
 $NugetVersion = (Get-PackageProvider -Name Nuget).Version
+if ( $NugetVersion -lt [Version]"2.8.5.201" ) {
+    $ErrorMessage = "The NuGet package provider in version 2.8.5.201 or higher is needed."
+    Fail-Json $result $ErrorMessage
+}
 
 $Repos = Get-PSRepository
 

--- a/lib/ansible/modules/windows/win_psrepository.py
+++ b/lib/ansible/modules/windows/win_psrepository.py
@@ -29,7 +29,7 @@ options:
   source_location:
     description:
       - URL of the custom repository to register.
-    aliasses:
+    aliases:
       - url
   state:
     description:
@@ -44,6 +44,7 @@ options:
     default: trusted
 notes:
   - Windows PowerShell 5.0 or higher is needed.
+  - The NuGet package provider version 2.8.5.201 or newer is required.
   - You can't use M(win_psrepository) to re-register (add) removed PSGallery, use the command `Register-PSRepository -Default` instead.
 author:
 - Wojciech Sciesinski (@it-praktyk)

--- a/lib/ansible/modules/windows/win_psrepository.py
+++ b/lib/ansible/modules/windows/win_psrepository.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Wojciech Sciesinski <wojciech[at]sciesinski[dot]net>
+# Copyright: (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: win_psrepository
+version_added: "2.8"
+short_description: Adds, removes or updates a Windows PowerShell repository.
+description:
+  - This module helps to install, remove and update Windows PowerShell repository on Windows-based systems.
+options:
+  name:
+    description:
+      - Name of the repository to work with.
+    aliases:
+      - repository
+    required: yes
+  source_location:
+    description:
+      - URL of the custom repository to register.
+    aliasses:
+      - url
+  state:
+    description:
+      - If C(present) a new repository is added or existing updated.
+      - If C(absent) a repository is removed.
+    choices: [ absent, present ]
+    default: present
+  installation_policy:
+    description:
+      - If present than property InstallationPolicy of the new or existing repository will be set using it.
+    choices: [ trusted, untrusted ]
+    default: trusted
+notes:
+  - Windows PowerShell 5.0 or higher is needed.
+  - You can't use M(win_psrepository) to re-register (add) removed PSGallery, use the command `Register-PSRepository -Default` instead.
+author:
+- Wojciech Sciesinski (@it-praktyk)
+- Daniele Lazzari (@dlazz)
+'''
+
+EXAMPLES = '''
+---
+- name: Add a PowerShell module and register a repository
+  win_psrepository:
+    name: MyRepository
+    source_location: https://myrepo.com
+    state: present
+
+- name: Remove a PowerShell repository
+  win_psrepository:
+    name: MyRepository
+    state: absent
+
+- name: Set InstallationPolicy to trusted
+  win_psrepository:
+    name: PSGallery
+    installation_policy: trusted
+'''
+
+RETURN = '''
+---
+output:
+  description: A message describing the task result.
+  returned: always
+  sample: "The repository MyInternal with the SourceLocation https://repo.example.com/api/v2 was registred."
+  type: string
+'''

--- a/test/integration/targets/win_psrepository/aliases
+++ b/test/integration/targets/win_psrepository/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group2

--- a/test/integration/targets/win_psrepository/defaults/main.yml
+++ b/test/integration/targets/win_psrepository/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+repository_name: MyGet
+repository_sourcelocation: https://www.myget.org/F/powershellgetdemo/api/v2

--- a/test/integration/targets/win_psrepository/tasks/main.yml
+++ b/test/integration/targets/win_psrepository/tasks/main.yml
@@ -1,0 +1,14 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2018, Wojciech Sciesinski <wojciech[at]sciesinski[dot]net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: get facts
+  setup:
+
+- name: Perform integration tests for Powershell 5+
+  when: ansible_powershell_version >= 5
+  block:
+
+    - name: run all tasks
+      include: test.yml

--- a/test/integration/targets/win_psrepository/tasks/test.yml
+++ b/test/integration/targets/win_psrepository/tasks/test.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: install updated NuGet version
+  win_shell: 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force'
+
 - name: get an existance of the PSGallery and its InstallationPolicy
   win_shell: '(Get-PSRepository -Name PSGallery).InstallationPolicy'
   register: policy

--- a/test/integration/targets/win_psrepository/tasks/test.yml
+++ b/test/integration/targets/win_psrepository/tasks/test.yml
@@ -1,0 +1,82 @@
+---
+
+- name: get an existance of the PSGallery and its InstallationPolicy
+  win_shell: '(Get-PSRepository -Name PSGallery).InstallationPolicy'
+  register: policy
+  changed_when: false
+
+- debug:
+    msg: '{{ policy.stdout | trim }}'
+  register: policy
+
+- name: check setting of InstallationPolicy
+  win_psrepository:
+    name: PSGallery
+    installation_policy: trusted
+  when: policy.msg == "Untrusted"
+  register: change_installation_policy_1
+
+- name: test check setting of InstallationPolicy
+  assert:
+    that:
+      - "change_installation_policy_1 is changed"
+      - "change_installation_policy_1.output == 'The InstallationPolicy for the repository PSGallery was changed to trusted.'"
+
+- name: check setting of InstallationPolicy idempotency
+  win_psrepository:
+    name: PSGallery
+    installation_policy: trusted
+  register: change_installation_policy_2
+
+- name: test check setting of InstallationPolicy idempotency
+  assert:
+    that:
+      - "change_installation_policy_2 is not changed"
+
+- name: check adding of repository
+  win_psrepository:
+    name: "{{ repository_name }}"
+    source_location: "{{ repository_sourcelocation }}"
+    state: present
+  register: adding_repository_1
+
+- name: test adding of repository
+  assert:
+      that:
+        - "adding_repository_1 is changed"
+        - "adding_repository_1.output == 'The repository {{ repository_name }} with the SourceLocation {{ repository_sourcelocation }} was registered.'"
+
+- name: check adding of repository idempotency
+  win_psrepository:
+    name: "{{ repository_name }}"
+    source_location: "{{ repository_sourcelocation }}"
+    state: present
+  register: adding_repository_2
+
+- name: test adding of repository idempotency
+  assert:
+      that:
+        - "adding_repository_2 is not changed"
+
+- name: check removing of repository
+  win_psrepository:
+    name: "{{ repository_name }}"
+    state: absent
+  register: removing_repository_1
+
+- name: test removing of repository
+  assert:
+    that:
+      - "removing_repository_1 is changed"
+      - "removing_repository_1.output == 'The repository {{ repository_name }} was unregistered.'"
+
+- name: check removing of repository idempotency
+  win_psrepository:
+    name: "{{ repository_name }}"
+    state: absent
+  register: removing_repository_2
+
+- name: test removing of repository idempotency
+  assert:
+    that:
+      - "removing_repository_2 is not changed"


### PR DESCRIPTION
##### SUMMARY
The new module win_psrepository adds, removes or updates a Windows PowerShell repository.

It was discussed under #46516.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_psrepository

##### ADDITIONAL INFORMATION
The module moves - with updates - the code related to managing PowerShell repositories from the module win_psmodule.