### PR TITLE
nmcli: fix NetworkManager-glib package obsoleted

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -20,11 +20,11 @@ DOCUMENTATION = '''
 module: nmcli
 author: "Chris Long (@alcamie101)"
 short_description: Manage Networking
-requirements: [ nmcli, dbus, NetworkManager-glib ]
+requirements: [ nmcli, dbus, NetworkManager-libnm ]
 version_added: "2.0"
 description:
     - Manage the network devices. Create, modify and manage various connection and device type e.g., ethernet, teams, bonds, vlans etc.
-    - "On CentOS and Fedora like systems, install dependencies as 'yum/dnf install -y python-gobject NetworkManager-glib'"
+    - "On CentOS and Fedora like systems, install dependencies as 'yum/dnf install -y python-gobject NetworkManager-libnm'"
     - "On Ubuntu and Debian like systems, install dependencies as 'apt-get install -y libnm-glib-dev'"
 options:
     state:
@@ -318,7 +318,7 @@ EXAMPLES = '''
       name: '{{ item }}'
       state: installed
     with_items:
-      - NetworkManager-glib
+      - NetworkManager-libnm
       - libnm-qt-devel.x86_64
       - nm-connection-editor.x86_64
       - libsemanage-python
@@ -501,10 +501,9 @@ except ImportError:
 
 try:
     import gi
-    gi.require_version('NMClient', '1.0')
-    gi.require_version('NetworkManager', '1.0')
+    gi.require_version('NM', '1.0')
 
-    from gi.repository import NetworkManager, NMClient
+    from gi.repository import NM
     HAVE_NM_CLIENT = True
 except (ImportError, ValueError):
     HAVE_NM_CLIENT = False


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Please see https://bugzilla.redhat.com/show_bug.cgi?id=1570875
and https://developer.gnome.org/libnm/stable/usage.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

         "vxlan_local": null,
            "vxlan_remote": null
        }
    },
    "msg": "This module requires NetworkManager glib API"
}
	to retry, use: --limit @/home/sus/ansible/ipip-nmcli.retry

PLAY RECAP ************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0   
```
Closes https://github.com/ansible/ansible/issues/48055
Signed-off-by: Susant Sahani <susant@redhat.com>
